### PR TITLE
Add PDF OCR extraction script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# CODEX-pdf-image-ocr-renamer
+# PDF OCR App
+
+A small command line tool to convert PDF files to images and extract text using Tesseract OCR.
+
+## Requirements
+
+- Python 3.8+
+- [pdf2image](https://pypi.org/project/pdf2image/)
+- [Pillow](https://pypi.org/project/Pillow/)
+- [pytesseract](https://pypi.org/project/pytesseract/)
+- Tesseract OCR installed on your system
+- Poppler utilities for PDF rendering
+
+Install the Python dependencies via pip:
+
+```bash
+pip install pdf2image Pillow pytesseract
+```
+
+## Usage
+
+```bash
+python pdf_ocr.py <file.pdf> --out-dir output --lang deu
+```
+
+All pages of the PDF will be saved as JPG images in the output folder. The recognized text is printed to the console and written to `output/output.txt`.
+
+## Notes
+
+This repository contains only a minimal example. Make sure `tesseract` and the language data you need are installed on your system.

--- a/pdf_ocr.py
+++ b/pdf_ocr.py
@@ -1,0 +1,45 @@
+import argparse
+import os
+from pdf2image import convert_from_path
+from PIL import Image
+import pytesseract
+
+
+def pdf_to_images(pdf_path, out_dir):
+    images = convert_from_path(pdf_path)
+    os.makedirs(out_dir, exist_ok=True)
+    image_paths = []
+    for i, image in enumerate(images, 1):
+        path = os.path.join(out_dir, f"page_{i}.jpg")
+        image.save(path, "JPEG")
+        image_paths.append(path)
+    return image_paths
+
+
+def images_to_text(image_paths, lang="deu"):
+    text_parts = []
+    for path in image_paths:
+        image = Image.open(path)
+        text = pytesseract.image_to_string(image, lang=lang)
+        text_parts.append(text)
+    return "\n".join(text_parts)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="PDF OCR extractor")
+    parser.add_argument("pdf", help="Input PDF file")
+    parser.add_argument("--out-dir", default="output", help="Directory for images and text")
+    parser.add_argument("--lang", default="deu", help="Tesseract language code")
+    args = parser.parse_args()
+
+    image_paths = pdf_to_images(args.pdf, args.out_dir)
+    text = images_to_text(image_paths, args.lang)
+    text_file = os.path.join(args.out_dir, "output.txt")
+    with open(text_file, "w", encoding="utf-8") as f:
+        f.write(text)
+    print(text)
+    print(f"Text saved to {text_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pdf2image
+Pillow
+pytesseract


### PR DESCRIPTION
## Summary
- implement pdf_ocr.py to convert PDFs to images and run tesseract OCR
- document usage and requirements in README
- add requirements.txt for dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eebdb8ad4832eb3ec7804d68f483a