### PR TITLE
Add HuggingFace OCR engine options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PDF OCR App
 
-A small command line tool to convert PDF files to images and extract text using Tesseract OCR.
+A small command line tool to convert PDF files to images and extract text. The default OCR engine is Tesseract but two Hugging Face models are also supported.
 
 ## Requirements
 
@@ -8,19 +8,20 @@ A small command line tool to convert PDF files to images and extract text using 
 - [pdf2image](https://pypi.org/project/pdf2image/)
 - [Pillow](https://pypi.org/project/Pillow/)
 - [pytesseract](https://pypi.org/project/pytesseract/)
+- [transformers](https://pypi.org/project/transformers/) and [torch](https://pypi.org/project/torch/) for the optional Hugging Face models
 - Tesseract OCR installed on your system
 - Poppler utilities for PDF rendering
 
 Install the Python dependencies via pip:
 
 ```bash
-pip install pdf2image Pillow pytesseract
+pip install -r requirements.txt
 ```
 
 ## Usage
 
 ```bash
-python pdf_ocr.py <file.pdf> --out-dir output --lang deu
+python pdf_ocr.py <file.pdf> --out-dir output --lang deu --engine tesseract
 ```
 
 All pages of the PDF will be saved as JPG images in the output folder. The recognized text is printed to the console and written to `output/output.txt`.

--- a/app.py
+++ b/app.py
@@ -33,8 +33,9 @@ def preview(sid):
     if not data:
         abort(404)
     if request.method == 'POST':
+        engine = request.form.get('engine', 'tesseract')
         lang = request.form.get('lang', 'deu')
-        text = images_to_text(data['images'], lang=lang)
+        text = images_to_text(data['images'], lang=lang, engine=engine)
         text_file = os.path.join(data['dir'], 'output.txt')
         with open(text_file, 'w', encoding='utf-8') as f:
             f.write(text)

--- a/pdf_ocr.py
+++ b/pdf_ocr.py
@@ -3,6 +3,16 @@ import os
 from pdf2image import convert_from_path
 from PIL import Image
 import pytesseract
+from typing import List
+
+try:
+    from transformers import AutoProcessor, Qwen2VLForConditionalGeneration, Qwen2_5_VLForConditionalGeneration
+    import torch
+except Exception:
+    AutoProcessor = None  # type: ignore
+    Qwen2VLForConditionalGeneration = None  # type: ignore
+    Qwen2_5_VLForConditionalGeneration = None  # type: ignore
+    torch = None  # type: ignore
 
 def pdf_to_images(pdf_path, out_dir):
     images = convert_from_path(pdf_path)
@@ -15,7 +25,7 @@ def pdf_to_images(pdf_path, out_dir):
     return image_paths
 
 
-def images_to_text(image_paths, lang="deu"):
+def _images_to_text_tesseract(image_paths: List[str], lang: str = "deu") -> str:
     text_parts = []
     for path in image_paths:
         image = Image.open(path)
@@ -24,15 +34,91 @@ def images_to_text(image_paths, lang="deu"):
     return "\n".join(text_parts)
 
 
+_qwen_processor = None
+_qwen_model = None
+
+
+def _ensure_qwen_loaded():
+    global _qwen_processor, _qwen_model
+    if _qwen_model is None:
+        if AutoProcessor is None:
+            raise RuntimeError("transformers is required for Qwen2 model")
+        QV_MODEL_ID = "prithivMLmods/Qwen2-VL-OCR-2B-Instruct"
+        _qwen_processor = AutoProcessor.from_pretrained(QV_MODEL_ID, trust_remote_code=True)
+        _qwen_model = Qwen2VLForConditionalGeneration.from_pretrained(
+            QV_MODEL_ID,
+            trust_remote_code=True,
+            torch_dtype=torch.float16,
+        ).to("cuda").eval()
+
+
+def _images_to_text_qwen(image_paths: List[str]) -> str:
+    _ensure_qwen_loaded()
+    results = []
+    for path in image_paths:
+        image = Image.open(path)
+        inputs = _qwen_processor(text="Recognize the text in the image", images=image, return_tensors="pt").to("cuda")
+        ids = _qwen_model.generate(**inputs, max_new_tokens=512)
+        text = _qwen_processor.batch_decode(ids, skip_special_tokens=True)[0]
+        results.append(text.strip())
+    return "\n".join(results)
+
+
+_rolm_processor = None
+_rolm_model = None
+
+
+def _ensure_rolm_loaded():
+    global _rolm_processor, _rolm_model
+    if _rolm_model is None:
+        if AutoProcessor is None:
+            raise RuntimeError("transformers is required for RolmOCR model")
+        ROLM_MODEL_ID = "reducto/RolmOCR"
+        _rolm_processor = AutoProcessor.from_pretrained(ROLM_MODEL_ID, trust_remote_code=True)
+        _rolm_model = Qwen2_5_VLForConditionalGeneration.from_pretrained(
+            ROLM_MODEL_ID,
+            trust_remote_code=True,
+            torch_dtype=torch.bfloat16,
+        ).to("cuda").eval()
+
+
+def _images_to_text_rolm(image_paths: List[str]) -> str:
+    _ensure_rolm_loaded()
+    results = []
+    for path in image_paths:
+        image = Image.open(path)
+        inputs = _rolm_processor(text="Recognize the text in the image", images=image, return_tensors="pt").to("cuda")
+        ids = _rolm_model.generate(**inputs, max_new_tokens=512)
+        text = _rolm_processor.batch_decode(ids, skip_special_tokens=True)[0]
+        results.append(text.strip())
+    return "\n".join(results)
+
+
+def images_to_text(image_paths: List[str], lang: str = "deu", engine: str = "tesseract") -> str:
+    if engine == "tesseract":
+        return _images_to_text_tesseract(image_paths, lang)
+    if engine == "qwen2":
+        return _images_to_text_qwen(image_paths)
+    if engine == "rolmocr":
+        return _images_to_text_rolm(image_paths)
+    raise ValueError(f"Unknown OCR engine: {engine}")
+
+
 def main():
     parser = argparse.ArgumentParser(description="PDF OCR extractor")
     parser.add_argument("pdf", help="Input PDF file")
     parser.add_argument("--out-dir", default="output", help="Directory for images and text")
     parser.add_argument("--lang", default="deu", help="Tesseract language code")
+    parser.add_argument(
+        "--engine",
+        default="tesseract",
+        choices=["tesseract", "qwen2", "rolmocr"],
+        help="OCR engine to use",
+    )
     args = parser.parse_args()
 
     image_paths = pdf_to_images(args.pdf, args.out_dir)
-    text = images_to_text(image_paths, args.lang)
+    text = images_to_text(image_paths, args.lang, args.engine)
     text_file = os.path.join(args.out_dir, "output.txt")
     with open(text_file, "w", encoding="utf-8") as f:
         f.write(text)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ pdf2image
 Pillow
 pytesseract
 Flask
+torch
+transformers

--- a/templates/preview.html
+++ b/templates/preview.html
@@ -8,7 +8,14 @@
 <h1>PDF Preview</h1>
 <img src="{{ url_for('uploaded_file', sid=sid, filename=first_image) }}" style="max-width:100%;" alt="preview">
 <form method="post">
-    <label for="lang">OCR Model:</label>
+    <label for="engine">OCR Engine:</label>
+    <select name="engine" id="engine">
+        <option value="tesseract" selected>Tesseract</option>
+        <option value="qwen2">Qwen2-VL-OCR-2B-Instruct</option>
+        <option value="rolmocr">RolmOCR</option>
+    </select>
+    <br>
+    <label for="lang">Language (Tesseract only):</label>
     <select name="lang" id="lang">
         <option value="eng">English</option>
         <option value="deu" selected>Deutsch</option>


### PR DESCRIPTION
## Summary
- include `--engine` CLI option
- add Qwen2 and RolmOCR model helpers
- allow engine selection in the preview page
- update README and requirements

## Testing
- `python -m py_compile pdf_ocr.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_684fe2d6eea4832ebab3845048214578